### PR TITLE
implement persistant destination storage

### DIFF
--- a/store/DriverContext.tsx
+++ b/store/DriverContext.tsx
@@ -10,8 +10,9 @@ import {
     updateLocation
 } from "@/model/Driver";
 import { getDistanceFrom, Location } from "@/model/Location";
-import { createContext, useContext, useReducer } from "react";
+import { createContext, useContext, useEffect, useReducer } from "react";
 import { LayoutAnimation } from "react-native";
+import { PersistantStoreService } from "./PersistantStoreService";
 
 type DriverState = Driver;
 
@@ -104,9 +105,10 @@ interface DriverCtxProviderProps {
 }
 
 function DriverCtxProvider({ children }: DriverCtxProviderProps) {
+    const storeService = new PersistantStoreService();
     const [driverState, driverDispatch] = useReducer<DriverReducerType>(driverStateReducer, {
         currentLocation: { latitude: 5, longitude: 5, address: null },
-        destinations: [
+        destinations: storeService.getDestinations() ?? [
             {
                 latitude: 4,
                 longitude: 5,
@@ -142,6 +144,12 @@ function DriverCtxProvider({ children }: DriverCtxProviderProps) {
         ],
         direction: { degrees: 50 }
     });
+
+    useEffect(() => {
+        storeService.setDestinationsAsync(driverState.destinations).catch((err) => {
+            console.error("Error saving destinations: ", err);
+        });
+    }, [driverState]);
 
     function updateLocation(location: Location) {
         driverDispatch({ type: DriverActionTypes.UPDATE_LOCATION, payload: location });

--- a/store/PersistantStoreService.ts
+++ b/store/PersistantStoreService.ts
@@ -1,0 +1,45 @@
+import { Platform } from "react-native";
+import { Destination } from "@/model/Destination";
+import * as SecureStore from "expo-secure-store";
+
+const isWeb = Platform.OS === "web";
+
+export class PersistantStoreService {
+    getDestinations(): Destination[] | null {
+        const destinations = isWeb ? localStorage.getItem("destinations") : SecureStore.getItem("destinations");
+
+        if (!destinations) {
+            return null;
+        }
+
+        return JSON.parse(destinations);
+    }
+
+    async getDestinationsAsync(): Promise<Destination[] | null> {
+        const destinations = isWeb
+            ? localStorage.getItem("destinations")
+            : await SecureStore.getItemAsync("destinations");
+
+        if (!destinations) {
+            return null;
+        }
+
+        return JSON.parse(destinations);
+    }
+
+    setDestinations(destinations: Destination[]): void {
+        if (isWeb) {
+            localStorage.setItem("destinations", JSON.stringify(destinations));
+        } else {
+            SecureStore.setItem("destinations", JSON.stringify(destinations));
+        }
+    }
+
+    async setDestinationsAsync(destinations: Destination[]): Promise<void> {
+        if (isWeb) {
+            localStorage.setItem("destinations", JSON.stringify(destinations));
+        } else {
+            await SecureStore.setItemAsync("destinations", JSON.stringify(destinations));
+        }
+    }
+}


### PR DESCRIPTION
### Notes
- Implemented storing the destinations on the system so that the system remembers them past shutdown
- Control flow is basically:
    - On startup: loads destinations from system. If none are found then defaults to our default list
    - On each state update of the destinations list, update it in the system
- Uses Expo's persistant storage API on mobile and localStorage web, as recommended on this post https://stackoverflow.com/questions/71341573/typeerror-exposecurestore-default-getvaluewithkeyasync-is-not-a-function

### Testing
- Did not test mobile on Expo Go yet