### PR TITLE
implement persistant destination storage

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -1,0 +1,2 @@
+<key>NSCameraUsageDescription</key>
+<string>Allow ParcelMarshall to use the camera</string>

--- a/app.json
+++ b/app.json
@@ -32,6 +32,13 @@
                     "resizeMode": "contain",
                     "backgroundColor": "#ffffff"
                 }
+            ],
+            [
+                "expo-secure-store",
+                {
+                    "configureAndroidBackup": true,
+                    "faceIDPermission": "Allow ParcelMarshall to access your Face ID biometric data."
+                }
             ]
         ],
         "experiments": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "expo-haptics": "~14.0.1",
         "expo-linking": "~7.0.5",
         "expo-router": "~4.0.20",
+        "expo-secure-store": "~14.0.1",
         "expo-splash-screen": "~0.29.22",
         "expo-status-bar": "~2.0.1",
         "expo-symbols": "~0.2.2",
@@ -6941,6 +6942,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/expo-secure-store": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-14.0.1.tgz",
+      "integrity": "sha512-QUS+j4+UG4jRQalgnpmTvvrFnMVLqPiUZRzYPnG3+JrZ5kwVW2w6YS3WWerPoR7C6g3y/a2htRxRSylsDs+TaQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-splash-screen": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "~4.4.0",
     "react-native-web": "~0.19.13",
-    "react-native-webview": "13.12.5"
+    "react-native-webview": "13.12.5",
+    "expo-secure-store": "~14.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/store/DriverContext.tsx
+++ b/store/DriverContext.tsx
@@ -10,8 +10,9 @@ import {
     updateLocation
 } from "@/model/Driver";
 import { getDistanceFrom, Location } from "@/model/Location";
-import { createContext, useContext, useReducer } from "react";
+import { createContext, useContext, useEffect, useReducer } from "react";
 import { LayoutAnimation } from "react-native";
+import { PersistantStoreService } from "./PersistantStoreService";
 
 type DriverState = Driver;
 
@@ -104,9 +105,10 @@ interface DriverCtxProviderProps {
 }
 
 function DriverCtxProvider({ children }: DriverCtxProviderProps) {
+    const storeService = new PersistantStoreService();
     const [driverState, driverDispatch] = useReducer<DriverReducerType>(driverStateReducer, {
         currentLocation: { latitude: 5, longitude: 5, address: null },
-        destinations: [
+        destinations: storeService.getDestinations() ?? [
             {
                 latitude: 4,
                 longitude: 5,
@@ -142,6 +144,12 @@ function DriverCtxProvider({ children }: DriverCtxProviderProps) {
         ],
         direction: { degrees: 50 }
     });
+
+    useEffect(() => {
+        storeService.setDestinationsAsync(driverState.destinations).catch((err) => {
+            console.error("Error saving destinations: ", err);
+        });
+    }, [driverState]);
 
     function updateLocation(location: Location) {
         driverDispatch({ type: DriverActionTypes.UPDATE_LOCATION, payload: location });

--- a/store/DriverContext.tsx
+++ b/store/DriverContext.tsx
@@ -15,6 +15,8 @@ import { getDistanceFrom, Location } from "@/model/Location";
 import { createContext, useContext, useEffect, useReducer } from "react";
 import { LayoutAnimation } from "react-native";
 import { PersistantStoreService } from "./PersistantStoreService";
+import { useNavigationState } from "@react-navigation/native"; // You had the wrong quotes in original
+
 
 
 
@@ -110,6 +112,9 @@ interface DriverCtxProviderProps {
 
 function DriverCtxProvider({ children }: DriverCtxProviderProps) {
 
+    const routeName = useNavigationState((state) => state.routes[state.index]?.name);
+
+    
     const storeService = new PersistantStoreService();
 
 
@@ -154,10 +159,26 @@ function DriverCtxProvider({ children }: DriverCtxProviderProps) {
     });
 
     useEffect(() => {
+    switch (routeName) {
+        case RouteName.Index:
+            sortDestinationByProximity();
+            break;
+        case RouteName.Route:
+            sortDestinationByFastestRoute();
+            break;
+        case RouteName.Settings:
+            throw new Error("How are you updating destinations state in settings?");
+        default:
+            console.log(`DriverCtxProvider: Unknown route name: ${routeName}`);
+    }
+}, [routeName]);
 
-        storeService.setDestinationsAsync(driverState.destinations).catch((err) => {
-            console.error("Error saving destinations: ", err);
-        });
+useEffect(() => {
+    storeService.setDestinationsAsync(driverState.destinations).catch((err) => {
+        console.error("Error saving destinations: ", err);
+    });
+}, [driverState.destinations]);
+
 
 
     function updateLocation(location: Location) {

--- a/store/PersistantStoreService.ts
+++ b/store/PersistantStoreService.ts
@@ -1,0 +1,45 @@
+import { Platform } from "react-native";
+import { Destination } from "@/model/Destination";
+import * as SecureStore from "expo-secure-store";
+
+const isWeb = Platform.OS === "web";
+
+export class PersistantStoreService {
+    getDestinations(): Destination[] | null {
+        const destinations = isWeb ? localStorage.getItem("destinations") : SecureStore.getItem("destinations");
+
+        if (!destinations) {
+            return null;
+        }
+
+        return JSON.parse(destinations);
+    }
+
+    async getDestinationsAsync(): Promise<Destination[] | null> {
+        const destinations = isWeb
+            ? localStorage.getItem("destinations")
+            : await SecureStore.getItemAsync("destinations");
+
+        if (!destinations) {
+            return null;
+        }
+
+        return JSON.parse(destinations);
+    }
+
+    setDestinations(destinations: Destination[]): void {
+        if (isWeb) {
+            localStorage.setItem("destinations", JSON.stringify(destinations));
+        } else {
+            SecureStore.setItem("destinations", JSON.stringify(destinations));
+        }
+    }
+
+    async setDestinationsAsync(destinations: Destination[]): Promise<void> {
+        if (isWeb) {
+            localStorage.setItem("destinations", JSON.stringify(destinations));
+        } else {
+            await SecureStore.setItemAsync("destinations", JSON.stringify(destinations));
+        }
+    }
+}


### PR DESCRIPTION
### Notes
- Implemented storing the destinations on the system so that the system remembers them past shutdown
- Control flow is basically:
    - On startup: loads destinations from system. If none are found then defaults to our default list
    - On each state update of the destinations list, update it in the system
- Uses Expo's persistant storage API on mobile and localStorage web, as recommended on this post https://stackoverflow.com/questions/71341573/typeerror-exposecurestore-default-getvaluewithkeyasync-is-not-a-function

### Testing
- Did not test mobile on Expo Go yet