### PR TITLE
implement address modification

### DIFF
--- a/components/DestinationCard.tsx
+++ b/components/DestinationCard.tsx
@@ -1,8 +1,11 @@
-import { getCompassDirectionAbbreviation } from "@/model/CompassDirection";
+import React, { useState } from "react";
+import { Ionicons } from "@expo/vector-icons";
 import { Destination } from "@/model/Destination";
-import { getCompassDirection } from "@/model/Direction";
 import { useDriver } from "@/store/DriverContext";
+import { EditAddressModal } from "./EditAddressModal";
+import { getCompassDirection } from "@/model/Direction";
 import { Pressable, StyleSheet, Text, View } from "react-native";
+import { getCompassDirectionAbbreviation } from "@/model/CompassDirection";
 
 interface DestinationCardProps {
     readonly destination: Destination;
@@ -10,52 +13,90 @@ interface DestinationCardProps {
 }
 
 export function DestinationCard({ destination, isCurrent = false }: DestinationCardProps) {
-    const { removeDestination } = useDriver();
+    const { removeDestination, updateDestination } = useDriver();
+    const [isModalVisible, setIsModalVisible] = useState(false);
+
+    const handleSaveAddress = (newAddress: string) => {
+        updateDestination(destination, { address: newAddress });
+        setIsModalVisible(false);
+    };
 
     return (
-        <View style={[styles.card, isCurrent && styles.currentCard]}>
-            <Text>{destination.address}</Text>
-            <Text>
-                {destination.travelDistance}mi 🧭{" "}
-                {getCompassDirectionAbbreviation(getCompassDirection(destination.travelDirection))}
-            </Text>
-            <Pressable style={styles.removeBtn} onPress={() => removeDestination(destination)}>
-                <Text>❌</Text>
-            </Pressable>
-        </View>
+        <>
+            <View style={[styles.card, isCurrent && styles.currentCard]}>
+                <View>
+                    <Text>{destination.address}</Text>
+                    <Text>
+                        {destination.travelDistance}mi 🧭{" "}
+                        {getCompassDirectionAbbreviation(getCompassDirection(destination.travelDirection))}
+                    </Text>
+                </View>
+
+                <View style={styles.buttonsContainer}>
+                    <Pressable style={styles.editBtn} onPress={() => setIsModalVisible(true)}>
+                        <Text>
+                            <Ionicons name="pencil" size={16} color="black" />
+                        </Text>
+                    </Pressable>
+                    <Pressable style={styles.removeBtn} onPress={() => removeDestination(destination)}>
+                        <Text>
+                            <Ionicons name="trash" size={16} color="black" />
+                        </Text>
+                    </Pressable>
+                </View>
+            </View>
+
+            <EditAddressModal
+                isVisible={isModalVisible}
+                destination={destination}
+                onSave={handleSaveAddress}
+                onClose={() => setIsModalVisible(false)}
+            />
+        </>
     );
 }
 
 const styles = StyleSheet.create({
     card: {
-        backgroundColor: "#ffffff", // cleaner white background
+        backgroundColor: "#ffffff",
         padding: 12,
         borderRadius: 8,
         marginBottom: 10,
-
-        // Soft outline
         borderWidth: 1,
-        borderColor: "#ddd", // light gray border
-
-        // Subtle shadow (good fallback for web)
+        borderColor: "#ddd",
         shadowColor: "#000",
         shadowOpacity: 0.05,
         shadowRadius: 4,
         shadowOffset: { width: 0, height: 2 },
-
-        // Web-friendly elevation
-        elevation: 2
+        elevation: 2,
+        display: "flex",
+        flexDirection: "row",
+        justifyContent: "space-between",
+        alignItems: "center"
     },
-
     currentCard: {
         borderColor: "#3366ff",
         borderWidth: 2,
         backgroundColor: "#e6f0ff"
     },
+    buttonsContainer: {
+        display: "flex",
+        flexDirection: "row",
+        alignItems: "center",
+        gap: 12
+    },
+    editBtn: {
+        padding: 8,
+        borderRadius: 8,
+        backgroundColor: "#f0f0f0",
+        borderWidth: 1,
+        borderColor: "#ddd"
+    },
     removeBtn: {
-        position: "absolute",
-        top: 10,
-        right: 10,
-        padding: 4
+        padding: 8,
+        borderRadius: 8,
+        backgroundColor: "#ff0000",
+        borderWidth: 1,
+        borderColor: "#ddd"
     }
 });

--- a/components/EditAddressModal.tsx
+++ b/components/EditAddressModal.tsx
@@ -1,0 +1,107 @@
+import { Ionicons } from "@expo/vector-icons";
+import React, { useState, useEffect } from "react";
+import { Modal, View, Text, TextInput, Button, StyleSheet, Pressable } from "react-native";
+import { Destination } from "@/model/Destination";
+
+interface EditAddressModalProps {
+    isVisible: boolean;
+    destination: Destination | null; // Allow null initially
+    onSave: (newAddress: string) => void;
+    onClose: () => void;
+}
+
+export function EditAddressModal({ isVisible, destination, onSave, onClose }: EditAddressModalProps) {
+    const [editedAddress, setEditedAddress] = useState("");
+
+    useEffect(() => {
+        if (destination) {
+            setEditedAddress(destination.address ?? "");
+        }
+    }, [destination]);
+
+    const handleSave = () => {
+        if (editedAddress.trim()) {
+            onSave(editedAddress);
+        } else {
+            console.warn("Address cannot be empty.");
+        }
+    };
+
+    if (!destination) {
+        return null;
+    }
+
+    return (
+        <Modal animationType="none" transparent={true} visible={isVisible} onRequestClose={onClose}>
+            <View style={styles.centeredView}>
+                <View style={styles.modalView}>
+                    <Pressable style={styles.closeButton} onPress={onClose}>
+                        <Ionicons name="close-circle" size={24} color="grey" />
+                    </Pressable>
+                    <Text style={styles.modalTitle}>Edit Address</Text>
+                    <TextInput
+                        style={styles.input}
+                        onChangeText={setEditedAddress}
+                        value={editedAddress}
+                        placeholder="Enter new address"
+                        autoFocus={true}
+                    />
+                    <View style={styles.buttonContainer}>
+                        <Button title="Cancel" onPress={onClose} color="#ff5c5c" />
+                        <Button title="Save" onPress={handleSave} />
+                    </View>
+                </View>
+            </View>
+        </Modal>
+    );
+}
+
+const styles = StyleSheet.create({
+    centeredView: {
+        flex: 1,
+        justifyContent: "center",
+        alignItems: "center",
+        backgroundColor: "rgba(0, 0, 0, 0.4)"
+    },
+    modalView: {
+        margin: 20,
+        backgroundColor: "white",
+        borderRadius: 10,
+        padding: 35,
+        alignItems: "center",
+        shadowColor: "#000",
+        shadowOffset: {
+            width: 0,
+            height: 2
+        },
+        shadowOpacity: 0.25,
+        shadowRadius: 4,
+        elevation: 5,
+        width: "80%"
+    },
+    modalTitle: {
+        marginBottom: 15,
+        textAlign: "center",
+        fontSize: 18,
+        fontWeight: "bold"
+    },
+    input: {
+        height: 40,
+        borderColor: "gray",
+        borderWidth: 1,
+        marginBottom: 20,
+        paddingHorizontal: 10,
+        width: "100%",
+        borderRadius: 5
+    },
+    buttonContainer: {
+        flexDirection: "row",
+        justifyContent: "space-around",
+        width: "100%"
+    },
+    closeButton: {
+        position: "absolute",
+        top: 10,
+        right: 10
+    }
+});

--- a/model/Driver.ts
+++ b/model/Driver.ts
@@ -1,4 +1,4 @@
-import { getDistanceFrom, Location } from "./Location";
+import { getDistanceFrom, getUniqueDestinationKey, Location } from "./Location";
 import { Direction } from "./Direction";
 import { Destination } from "./Destination";
 
@@ -20,12 +20,37 @@ export function addDestination(self: Driver, destination: Destination): Driver {
 export function removeDestination(self: Driver, destination: Destination): Driver {
     const newDestinations = [...self.destinations];
     const index = newDestinations.indexOf(destination);
-    newDestinations.splice(index, 1);
+    if (index > -1) {
+        // Only splice if found
+        newDestinations.splice(index, 1);
+    } else {
+        console.warn("removeDestination: Destination not found.");
+    }
     return { ...self, destinations: newDestinations };
 }
 
 export function updateDirection(self: Driver, direction: Direction): Driver {
     return { ...self, direction };
+}
+
+export function updateDestination(
+    self: Driver,
+    originalDestination: Destination,
+    updatedDestinationData: Partial<Destination>
+): Driver {
+    const index = self.destinations.findIndex(
+        (d) => getUniqueDestinationKey(d) === getUniqueDestinationKey(originalDestination)
+    );
+
+    if (index === -1) {
+        console.warn("updateDestination: Original destination not found, returning original state.");
+        return self;
+    }
+
+    const finalDestinations = [...self.destinations];
+    finalDestinations[index] = { ...finalDestinations[index], ...updatedDestinationData };
+
+    return { ...self, destinations: finalDestinations };
 }
 
 //adding code for testing purposes -STIN

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "parcelmarshall",
       "version": "1.0.0",
       "dependencies": {
-        "@expo/vector-icons": "^14.0.2",
+        "@expo/vector-icons": "^14.1.0",
         "@react-navigation/bottom-tabs": "^7.2.0",
         "@react-navigation/native": "^7.0.14",
         "expo": "~52.0.42",
@@ -2837,12 +2837,14 @@
       "license": "MIT"
     },
     "node_modules/@expo/vector-icons": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/@expo/vector-icons/-/vector-icons-14.0.4.tgz",
-      "integrity": "sha512-+yKshcbpDfbV4zoXOgHxCwh7lkE9VVTT5T03OUlBsqfze1PLy6Hi4jp1vSb1GVbY6eskvMIivGVc9SKzIv0oEQ==",
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@expo/vector-icons/-/vector-icons-14.1.0.tgz",
+      "integrity": "sha512-7T09UE9h8QDTsUeMGymB4i+iqvtEeaO5VvUjryFB4tugDTG/bkzViWA74hm5pfjjDEhYMXWaX112mcvhccmIwQ==",
       "license": "MIT",
-      "dependencies": {
-        "prop-types": "^15.8.1"
+      "peerDependencies": {
+        "expo-font": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/@expo/ws-tunnel": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "collectCoverage": true
   },
   "dependencies": {
-    "@expo/vector-icons": "^14.0.2",
+    "@expo/vector-icons": "^14.1.0",
     "@react-navigation/bottom-tabs": "^7.2.0",
     "@react-navigation/native": "^7.0.14",
     "expo": "~52.0.42",
@@ -27,6 +27,7 @@
     "expo-haptics": "~14.0.1",
     "expo-linking": "~7.0.5",
     "expo-router": "~4.0.20",
+    "expo-secure-store": "~14.0.1",
     "expo-splash-screen": "~0.29.22",
     "expo-status-bar": "~2.0.1",
     "expo-symbols": "~0.2.2",
@@ -40,8 +41,7 @@
     "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "~4.4.0",
     "react-native-web": "~0.19.13",
-    "react-native-webview": "13.12.5",
-    "expo-secure-store": "~14.0.1"
+    "react-native-webview": "13.12.5"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/store/DriverContext.tsx
+++ b/store/DriverContext.tsx
@@ -7,15 +7,15 @@ import {
     removeDestination,
     sortDestinationsByFastestRoute,
     sortDestinationsByProximity,
+    updateDestination,
     updateDirection,
     updateLocation
 } from "@/model/Driver";
-import { getDistanceFrom, Location } from "@/model/Location";
+import { Location } from "@/model/Location";
 
 import { createContext, useContext, useEffect, useReducer } from "react";
-import { LayoutAnimation } from "react-native";
 import { PersistantStoreService } from "./PersistantStoreService";
-import { useNavigationState } from "@react-navigation/native"; // You had the wrong quotes in original
+import { useNavigationState } from "@react-navigation/native";
 
 type DriverState = Driver;
 
@@ -24,6 +24,7 @@ interface DriverContextType {
     updateLocation: (location: Location) => void;
     addDestination: (destination: Destination) => void;
     removeDestination: (destination: Destination) => void;
+    updateDestination: (originalDestination: Destination, updatedData: Partial<Destination>) => void; // Added
     sortDestinationByProximity: () => void;
     sortDestinationByFastestRoute: () => void;
     updateDirection: (direction: Direction) => void;
@@ -35,11 +36,13 @@ enum DriverActionTypes {
     UPDATE_LOCATION = "UPDATE_LOCATION",
     ADD_DESTINATION = "ADD_DESTINATION",
     REMOVE_DESTINATION = "REMOVE_DESTINATION",
+    UPDATE_DESTINATION = "UPDATE_DESTINATION", // Added
     SORT_DEST_BY_PROXIMITY = "SORT_DEST_BY_PROXIMITY",
     SORT_DEST_BY_FASTEST_ROUTE = "SORT_DEST_BY_FASTEST_ROUTE",
     UPDATE_DIRECTION = "UPDATE_DIRECTION"
 }
 
+// Action Types
 type UpdateLocationAction = {
     type: DriverActionTypes.UPDATE_LOCATION;
     payload: Location;
@@ -55,6 +58,15 @@ type RemoveDestinationAction = {
     payload: Destination;
 };
 
+// Added Action Type
+type UpdateDestinationAction = {
+    type: DriverActionTypes.UPDATE_DESTINATION;
+    payload: {
+        originalDestination: Destination;
+        updatedData: Partial<Destination>;
+    };
+};
+
 type SortDestinationByProximityAction = {
     type: DriverActionTypes.SORT_DEST_BY_PROXIMITY;
 };
@@ -68,14 +80,17 @@ type UpdateDirectionAction = {
     payload: Direction;
 };
 
+// Union Type including new action
 type DriverStateAction =
     | UpdateLocationAction
     | AddDestinationAction
     | RemoveDestinationAction
+    | UpdateDestinationAction // Added
     | SortDestinationByProximityAction
     | SortDestinationByFastestRouteAction
     | UpdateDirectionAction;
 
+// Reducer
 type DriverReducerType = (prevState: Driver, action: DriverStateAction) => Driver;
 const driverStateReducer: DriverReducerType = (state, action) => {
     switch (action.type) {
@@ -88,18 +103,22 @@ const driverStateReducer: DriverReducerType = (state, action) => {
         case DriverActionTypes.REMOVE_DESTINATION: {
             return removeDestination(state, action.payload);
         }
+        // Added Reducer Case
+        case DriverActionTypes.UPDATE_DESTINATION: {
+            return updateDestination(state, action.payload.originalDestination, action.payload.updatedData);
+        }
         case DriverActionTypes.SORT_DEST_BY_PROXIMITY: {
             return sortDestinationsByProximity(state);
         }
-        //fixed typo in action type
         case DriverActionTypes.SORT_DEST_BY_FASTEST_ROUTE: {
             return sortDestinationsByFastestRoute(state);
         }
-
         case DriverActionTypes.UPDATE_DIRECTION: {
             return updateDirection(state, action.payload);
         }
         default: {
+            // Ensure exhaustive check if needed, or just return state
+            // const exhaustiveCheck: never = action;
             return state;
         }
     }
@@ -111,7 +130,6 @@ interface DriverCtxProviderProps {
 
 function DriverCtxProvider({ children }: DriverCtxProviderProps) {
     const routeName = useNavigationState((state) => state.routes[state.index]?.name);
-
     const storeService = new PersistantStoreService();
 
     const [driverState, driverDispatch] = useReducer<DriverReducerType>(driverStateReducer, {
@@ -120,20 +138,16 @@ function DriverCtxProvider({ children }: DriverCtxProviderProps) {
             {
                 latitude: 4.7,
                 longitude: 5.7,
-                //travelDuration: 20,
                 travelDuration: 60,
                 address: "318 Meadow Brook Rd, Rochester, MI 48309",
-                //travelDistance: parseInt((Math.random() * 100).toFixed(0)),
                 travelDistance: 60,
-                //travelDirection: { degrees: 50 }
                 travelDirection: { degrees: 180 }
             },
             {
-                latitude: 5.1, // testing purposes
+                latitude: 5.1,
                 longitude: 5.1,
                 travelDuration: 20,
                 address: "Anton’s Discrete Math Asylum, UA 01001",
-                //travelDistance: parseInt((Math.random() * 100).toFixed(0)),
                 travelDistance: 10,
                 travelDirection: { degrees: 90 }
             },
@@ -150,7 +164,6 @@ function DriverCtxProvider({ children }: DriverCtxProviderProps) {
                 longitude: 4.1,
                 travelDuration: 50,
                 address: "Gavin's Rust Hideout, Rochester, MI 48309",
-                //travelDistance: parseInt((Math.random() * 100).toFixed(0)),
                 travelDistance: 70,
                 travelDirection: { degrees: 45 }
             },
@@ -185,11 +198,8 @@ function DriverCtxProvider({ children }: DriverCtxProviderProps) {
     useEffect(() => {
         switch (routeName) {
             case RouteName.Index:
-                //sortDestinationByProximity(); commenting out for now as i am handling this
-                // in update button
                 break;
             case RouteName.Route:
-                //sortDestinationByFastestRoute();
                 break;
             case RouteName.Settings:
                 break;
@@ -204,6 +214,7 @@ function DriverCtxProvider({ children }: DriverCtxProviderProps) {
         });
     }, [driverState.destinations]);
 
+    // Dispatch Functions
     function updateLocation(location: Location) {
         driverDispatch({ type: DriverActionTypes.UPDATE_LOCATION, payload: location });
     }
@@ -212,6 +223,13 @@ function DriverCtxProvider({ children }: DriverCtxProviderProps) {
     }
     function removeDestination(destination: Destination) {
         driverDispatch({ type: DriverActionTypes.REMOVE_DESTINATION, payload: destination });
+    }
+    // Added Dispatch Function
+    function updateDestination(originalDestination: Destination, updatedData: Partial<Destination>) {
+        driverDispatch({
+            type: DriverActionTypes.UPDATE_DESTINATION,
+            payload: { originalDestination, updatedData }
+        });
     }
     function sortDestinationByProximity() {
         driverDispatch({ type: DriverActionTypes.SORT_DEST_BY_PROXIMITY });
@@ -223,11 +241,13 @@ function DriverCtxProvider({ children }: DriverCtxProviderProps) {
         driverDispatch({ type: DriverActionTypes.UPDATE_DIRECTION, payload: direction });
     }
 
+    // Context Value including new function
     const ctxValue: DriverContextType = {
         driver: driverState,
         updateLocation,
         addDestination,
         removeDestination,
+        updateDestination, // Added
         sortDestinationByProximity,
         sortDestinationByFastestRoute,
         updateDirection


### PR DESCRIPTION
### Notes
- Creates a new pencil button on each destination card. Clicking the button opens a modal that lets us edit the destination's address and update the global state

### Testing
- Some manual testing, currently only works for home page (as expected)

<img width="1203" alt="image" src="https://github.com/user-attachments/assets/87c32b69-a1a5-426c-a128-4cded9334973" />

#21 